### PR TITLE
Fix type error through type coercion.

### DIFF
--- a/conv.fut
+++ b/conv.fut
@@ -78,7 +78,7 @@ module nn (F: real) = {
     --let (c1 : [6][24][24]real) = logistics3 (mconv2d inp k1 b1)
     let c1 = logistics3 (mconv2d inp k1 b1)
     --let s1 : [6][12][12]real = map avgp2 c1
-    let s1 = map avgp2 c1
+    let s1 = map avgp2 (c1 :> [6][12*2][12*2]F.t)
     in zero
 
   def main (n: i32) : real =


### PR DESCRIPTION
This is necessary because the Futhark type checker does not understand arithmetic. Sizes are *uninterpreted* terms, and are considered purely symbolically/syntactically. (The reasons for this are somewhat subtle, but it's not _just_ the case that we haven't gotten around to it - there are good reasons not to just do it in all cases.)

Also, there is no way to explicitly apply type parameters, but you can always use a type ascription (not a coercion) to make them what you want. This is very verbose, but perhaps OK for code generation.